### PR TITLE
Fix launch of CUDA and AMDGPU

### DIFF
--- a/julia/GemmDenseAMDGPU/src/GemmDenseAMDGPU.jl
+++ b/julia/GemmDenseAMDGPU/src/GemmDenseAMDGPU.jl
@@ -121,7 +121,9 @@ function main(args::Array{String,1})::Int32
         print("Time to fill B")
         @time AMDGPU.rand!(B)
 
-        grid = (A_rows, B_cols)
+        grid_rows::Int32 = cld(A_rows, BLOCK_SIZE)
+        grid_cols::Int32 = cld(B_colds, BLOCK_SIZE)
+        grid = (grid_rows, grid_cols)
         threads = (BLOCK_SIZE, BLOCK_SIZE)
 
         print("Time to simple gemm ")

--- a/julia/GemmDenseCUDA/src/GemmDenseCUDA.jl
+++ b/julia/GemmDenseCUDA/src/GemmDenseCUDA.jl
@@ -124,8 +124,8 @@ function main(args::Array{String,1})::Int32
         print("Time to fill B")
         @time CUDA.rand!(B)
 
-        grid_rows::Int32 = ceil((A_rows + BLOCK_SIZE - 1) / BLOCK_SIZE)
-        grid_cols::Int32 = ceil((B_cols + BLOCK_SIZE - 1) / BLOCK_SIZE)
+        grid_rows::Int32 = cld(A_rows, BLOCK_SIZE)
+        grid_cols::Int32 = cld(B_colds, BLOCK_SIZE)
         blocks = (grid_rows, grid_cols)
         threads = (BLOCK_SIZE, BLOCK_SIZE)
 


### PR DESCRIPTION
I was using the kernels today and I noticed two things.

1. The CUDA kernels launch blocks of (33,33) for (1024, 1024)
2. The AMDGPU kernels launch too many blocks due to the grid being very large.

